### PR TITLE
Descriptive output from throttling call 

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Returns the enabled and detected state of the official camera in JSON format. 1 
 
 #### get_throttled()
 
-Returns the throttled state of the system in JSON format. This is a bit pattern - a bit being set indicates the following meanings:
+Returns the throttled state of the system in dictionaries (similar to JSON format). This is a bit pattern - a bit being set indicates the following meanings:
 
 | Bit | Meaning |
 |:---:|---------|
@@ -109,6 +109,22 @@ Adding the bit numbers along the top we get:
 ```
 
 From this we can see that bits 18 and 16 are set, indicating that the Pi has previously been throttled due to under-voltage, but is not currently throttled for any reason.
+
+#### get_throttled_flags()
+
+Returns a dictionary of the same results as `get_throttled()` but with the descriptive names as the keys.
+
+```python
+>>> pprint.pp(out.get_throttled_flags())
+{'Under-voltage detected': False,
+ 'Arm frequency capped': False,
+ 'Currently throttled': False,
+ 'Soft temperature limit active': False,
+ 'Under-voltage has occurred': False,
+ 'Arm frequency capping has occurred': True,
+ 'Throttling has occurred': False,
+ 'Soft temperature limit has occurred': False}
+```
 
 #### measure_temp()
 

--- a/vcgencmd/vcgencmd.py
+++ b/vcgencmd/vcgencmd.py
@@ -32,7 +32,7 @@ class Vcgencmd:
 		return self.__sources.get(typ)
 
 	def vcos_version(self):
-		out = self.self.__verify_command("vcos version", "", [""])
+		out = self.__verify_command("vcos version", "", [""])
 		return str(out)
 
 	def vcos_log_status(self):

--- a/vcgencmd/vcgencmd.py
+++ b/vcgencmd/vcgencmd.py
@@ -4,7 +4,7 @@ import re
 
 class Vcgencmd:
 	__sources = {
-		"clock": ["arm", "core","H264", "isp", "v3d", "uart", "pwm", "emmc", "pixel", "vec", "hdmi", "dpi"],
+		"clock": ["arm", "core","h264", "isp", "v3d", "uart", "pwm", "emmc", "pixel", "vec", "hdmi", "dpi"],
 		"volts": ["core", "sdram_c", "sdram_i", "sdram_p"],
 		"mem": ["arm", "gpu"],
 		"codec": ["agif", "flac", "h263", "h264", "mjpa", "mjpb", "mjpg", "mpg2", "mpg4", "mvc0", "pcm", "thra", "vorb", "vp6", "vp8", "wmv9", "wvc1"],

--- a/vcgencmd/vcgencmd.py
+++ b/vcgencmd/vcgencmd.py
@@ -79,6 +79,26 @@ class Vcgencmd:
 		response["breakdown"]["19"] = state(binary_val[0:4][0])
 		return response
 
+	def get_throttled_flags(self):
+		bits = self.get_throttled()['breakdown']
+
+		mapping = {
+			"0": "Under-voltage detected",
+			"1": "Arm frequency capped",
+			"2": "Currently throttled",
+			"3": "Soft temperature limit active",
+			"16": "Under-voltage has occurred",
+			"17": "Arm frequency capping has occurred",
+			"18": "Throttling has occurred",
+			"19": "Soft temperature limit has occurred"
+		}
+
+		desc = {}
+		for bit, value in bits.items():
+			desc[mapping[bit]] = value
+		
+		return desc
+
 	def measure_temp(self):
 		out = self.__verify_command("measure_temp", "", [""])
 		return float(re.sub("[^\d\.]", "",out))


### PR DESCRIPTION
In addition to the existing method that returns the bit field, return a
dictionary with descriptive values, similar to mem_oom() and
mem_reloc_stats().