### PR TITLE
Printable overview of all stats 

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,59 @@ print(output)
 
 ```
 
+## Overview Output
+See status from all fields on the command line.
+
+```text
+$ sudo python3 -m vcgencmd
+Binary Version
+Nov 30 2020 22:12:08 
+Copyright (c) 2012 Broadcom
+version ab1181cc0cb6df52bfae3b1d3fef0ce7c325166c (clean) (release) (start)
+
+
+Clock Frequencies (Hz)
+arm                                 : 1500398464
+core                                : 500000992
+h264                                : 0
+isp                                 : 0
+v3d                                 : 500000992
+uart                                : 48001464
+pwm                                 : 0
+emmc                                : 250000496
+pixel                               : 75001464
+vec                                 : 0
+hdmi                                : 0
+dpi                                 : 0
+
+Voltages (V)
+core                                : 0.8375
+sdram_c                             : 1.1
+sdram_i                             : 1.1
+sdram_p                             : 1.1
+
+Memory (MB) (Not accurate on rpi4)
+arm                                 : 948
+gpu                                 : 76
+
+Temperatures (C)
+core                                : 75.9
+
+Video Core Log Status
+mmal                                : opaque
+gencmd_file                         : info
+wdog                                : warn
+
+<snip many lines>
+
+Display Status
+display 0                           : off
+display 1                           : off
+display 2                           : off
+display 3                           : off
+display 7                           : off
+```
+
 ## Commands
 
 #### get_sources(src)

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Returns the enabled and detected state of the official camera in JSON format. 1 
 
 #### get_throttled()
 
-Returns the throttled state of the system in JSON format. This is a bit pattern - a bit being set indicates the following meanings:
+Returns the throttled state of the system in dictionaries (similar to JSON format). This is a bit pattern - a bit being set indicates the following meanings:
 
 | Bit | Meaning |
 |:---:|---------|
@@ -109,6 +109,22 @@ Adding the bit numbers along the top we get:
 ```
 
 From this we can see that bits 18 and 16 are set, indicating that the Pi has previously been throttled due to under-voltage, but is not currently throttled for any reason.
+
+#### get_throttled_flags()
+
+Returns a dictionary of the same results as `get_throttled()` but with the descriptive names as the keys.
+
+```python
+>>> pprint.pp(out.get_throttled_flags())
+{'Under-voltage detected': False,
+ 'Arm frequency capped': False,
+ 'Currently throttled': False,
+ 'Soft temperature limit active': False,
+ 'Under-voltage has occurred': False,
+ 'Arm frequency capping has occurred': True,
+ 'Throttling has occurred': False,
+ 'Soft temperature limit has occurred': False}
+```
 
 #### measure_temp()
 

--- a/vcgencmd/__main__.py
+++ b/vcgencmd/__main__.py
@@ -1,10 +1,9 @@
-from .vcgencmd import Vcgencmd
+from .vcgencmd import print_overview
 import sys
 
 
 def main():
-	out = Vcgencmd().version()
-	print(out)
+	print_overview()
 
 if __name__ == "__main__":
 	sys.exit(main())

--- a/vcgencmd/vcgencmd.py
+++ b/vcgencmd/vcgencmd.py
@@ -32,7 +32,7 @@ class Vcgencmd:
 		return self.__sources.get(typ)
 
 	def vcos_version(self):
-		out = self.self.__verify_command("vcos version", "", [""])
+		out = self.__verify_command("vcos version", "", [""])
 		return str(out)
 
 	def vcos_log_status(self):

--- a/vcgencmd/vcgencmd.py
+++ b/vcgencmd/vcgencmd.py
@@ -4,7 +4,7 @@ import re
 
 class Vcgencmd:
 	__sources = {
-		"clock": ["arm", "core","H264", "isp", "v3d", "uart", "pwm", "emmc", "pixel", "vec", "hdmi", "dpi"],
+		"clock": ["arm", "core","h264", "isp", "v3d", "uart", "pwm", "emmc", "pixel", "vec", "hdmi", "dpi"],
 		"volts": ["core", "sdram_c", "sdram_i", "sdram_p"],
 		"mem": ["arm", "gpu"],
 		"codec": ["agif", "flac", "h263", "h264", "mjpa", "mjpb", "mjpg", "mpg2", "mpg4", "mvc0", "pcm", "thra", "vorb", "vp6", "vp8", "wmv9", "wvc1"],

--- a/vcgencmd/vcgencmd.py
+++ b/vcgencmd/vcgencmd.py
@@ -79,6 +79,26 @@ class Vcgencmd:
 		response["breakdown"]["19"] = state(binary_val[0:4][0])
 		return response
 
+	def get_throttled_flags(self):
+		bits = self.get_throttled()['breakdown']
+
+		mapping = {
+			"0": "Under-voltage detected",
+			"1": "Arm frequency capped",
+			"2": "Currently throttled",
+			"3": "Soft temperature limit active",
+			"16": "Under-voltage has occurred",
+			"17": "Arm frequency capping has occurred",
+			"18": "Throttling has occurred",
+			"19": "Soft temperature limit has occurred"
+		}
+
+		desc = {}
+		for bit, value in bits.items():
+			desc[mapping[bit]] = value
+		
+		return desc
+
 	def measure_temp(self):
 		out = self.__verify_command("measure_temp", "", [""])
 		return float(re.sub("[^\d\.]", "",out))

--- a/vcgencmd/vcgencmd.py
+++ b/vcgencmd/vcgencmd.py
@@ -237,3 +237,77 @@ class Vcgencmd:
 			return "off"
 		elif out.split("=")[1].strip() == "1":
 			return "on"
+
+def _print_dict(input_dict):
+	mm_fmt = "{:35s} : {}"
+	for key, val in input_dict.items():
+		print(mm_fmt.format(key, val))
+
+def print_overview():
+	mm_fmt = "{:35s} : {}"
+
+	stats = Vcgencmd()
+	print("Binary Version")
+	print(stats.version())
+
+	print("\nClock Frequencies (Hz)")
+	for clock in stats.get_sources("clock"):
+		val = stats.measure_clock(clock)
+		print(mm_fmt.format(clock, val))
+		
+	print("\nVoltages (V)")
+	for volt in stats.get_sources("volts"):
+		val = stats.measure_volts(volt)
+		print(mm_fmt.format(volt, val))
+		
+	print("\nMemory (MB) (Not accurate on rpi4)")
+	for mem in stats.get_sources("mem"):
+		val = stats.get_mem(mem)
+		print(mm_fmt.format(mem, val))
+
+	print("\nTemperatures (C)")
+	val = stats.measure_temp()
+	print(mm_fmt.format("core", val))
+
+	print("\nVideo Core Log Status")
+	_print_dict(stats.vcos_log_status())
+
+	print("\nCamera")
+	status = stats.get_camera()
+	print(mm_fmt.format("supported", status["supported"]))
+	print(mm_fmt.format("detected", status["detected"]))
+
+	print("\nThrottling")
+	_print_dict(stats.get_throttled_flags())
+
+	print("\nOne Time Programmable Memory")
+	_print_dict(stats.otp_dump())
+
+	print("\nCodecs Enabled")
+	for codec in stats.get_sources("codec"):
+		val = stats.codec_enabled(codec)
+		print(mm_fmt.format(codec, val))
+
+	print("\nBoot Config Values (config.txt effective values)")
+	_print_dict(stats.get_config("str"))
+	_print_dict(stats.get_config("int"))
+
+	print("\nLCD (px)")
+	_print_dict(stats.get_lcd_info())
+
+	print("\nstats Of Memory Events")
+	_print_dict(stats.mem_oom())
+
+	print("\nRelocatable Memory")
+	_print_dict(stats.mem_reloc_stats())
+
+	print("\nRing Oscillator")
+	_print_dict(stats.read_ring_osc())
+
+	print("\nHDMI Timings")
+	_print_dict(stats.hdmi_timings()["breakdown"])
+
+	print("\nDisplay Status")
+	for disp in stats.get_sources("display_id"):
+		val = stats.display_power_state(disp)
+		print(mm_fmt.format("display " + str(disp), val))


### PR DESCRIPTION
Added a simple helper function that prints out all the relevant
details. Set it to be what runs from main with a
`python3 -m vcgencmd` call.