### PR TITLE
Libcamera interfaces  fix for get_camera

### DIFF
--- a/vcgencmd/vcgencmd.py
+++ b/vcgencmd/vcgencmd.py
@@ -52,11 +52,15 @@ class Vcgencmd:
 
 	def get_camera(self):
 		out = self.__verify_command("get_camera", "", [""])
+		out = out.replace("libcamera interfaces","libcamera_interfaces")
 		out = out.split(" ")
 		out = list(filter(None, out))
 		response = {}
 		for i in out:
 			j = i.split("=")
+			if len(j)<2:
+				response[j[0].strip()] = None
+				continue
 			response[j[0].strip()] = j[1].strip()
 		return response
 


### PR DESCRIPTION
-Modified get_camera

Fox for behavior:

>>> from vcgencmd import Vcgencmd
>>> 
>>> vcgm = Vcgencmd()
>>> output = vcgm.version()
>>> output = vcgm.get_camera()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python3.11/dist-packages/vcgencmd/vcgencmd.py", line 60, in get_camera
    response[j[0].strip()] = j[1].strip()
                             ~^^^
IndexError: list index out of range


Where
	vcgencmd get_camera
Returns 
	supported=1 detected=1, libcamera interfaces=0



After this merge the expected output of the function is:
{'supported': '1', 'detected': '1,', 'libcamera_interfaces': '0'}

